### PR TITLE
Fix provider prop types

### DIFF
--- a/.changeset/long-bees-wash.md
+++ b/.changeset/long-bees-wash.md
@@ -1,0 +1,5 @@
+---
+'jotai-x': patch
+---
+
+Fix: Provider prop types expect atoms instead of values for stores created with custom atoms

--- a/packages/jotai-x/src/createAtomStore.spec.tsx
+++ b/packages/jotai-x/src/createAtomStore.spec.tsx
@@ -483,7 +483,7 @@ describe('createAtomStore', () => {
       isCustomAtom: true,
     });
 
-    const { customStore } = createAtomStore(
+    const { customStore, useCustomStore, CustomProvider } = createAtomStore(
       {
         x: createCustomAtom(1),
       },
@@ -495,6 +495,16 @@ describe('createAtomStore', () => {
     it('uses passed atom', () => {
       const myAtom = customStore.atom.x as CustomAtom<number>;
       expect(myAtom.isCustomAtom).toBe(true);
+    });
+
+    it('accepts initial values', () => {
+      const { result } = renderHook(() => useCustomStore().get.x(), {
+        wrapper: ({ children }) => (
+          <CustomProvider x={2}>{children}</CustomProvider>
+        ),
+      });
+
+      expect(result.current).toBe(2);
     });
   });
 


### PR DESCRIPTION
**Description**

See changesets.

Previously, if a store was created with a custom atom, the provider component props types would expect an atom to be passed instead of a value.