### PR TITLE
feat: add get<Name>Store function for non-React access

### DIFF
--- a/packages/jotai-x/src/createAtomStore.spec.tsx
+++ b/packages/jotai-x/src/createAtomStore.spec.tsx
@@ -1110,6 +1110,37 @@ describe('createAtomStore', () => {
       const second = result.current;
       expect(first === second).toBeTruthy();
     });
+
+    it('getMyTestStoreStore returns a store without hooks', () => {
+      const { getMyTestStoreStore } = createAtomStore(initialTestStoreValue, {
+        name: 'myTestStore' as const,
+      });
+
+      // Should be able to call getMyTestStoreStore outside of React
+      const store = getMyTestStoreStore();
+
+      // Should have all the same methods as useMyTestStoreStore
+      expect(typeof store.getName).toBe('function');
+      expect(typeof store.setName).toBe('function');
+      expect(typeof store.getAge).toBe('function');
+      expect(typeof store.setAge).toBe('function');
+      expect(typeof store.get).toBe('function');
+      expect(typeof store.set).toBe('function');
+      expect(typeof store.subscribe).toBe('function');
+      expect(typeof store.getAtom).toBe('function');
+      expect(typeof store.setAtom).toBe('function');
+      expect(typeof store.subscribeAtom).toBe('function');
+
+      // Should be able to get and set values
+      expect(store.getName()).toBe(INITIAL_NAME);
+      expect(store.getAge()).toBe(INITIAL_AGE);
+
+      store.setName('New Name');
+      expect(store.getName()).toBe('New Name');
+
+      store.set('age', 100);
+      expect(store.get('age')).toBe(100);
+    });
   });
 
   describe('scoped providers', () => {


### PR DESCRIPTION
## Summary
- Adds a new `get<Name>Store` function that provides access to the store API without requiring React hooks
- Enables usage of jotai-x stores outside of React components or in scenarios where hooks cannot be used

## Motivation
As discussed in the issue, there are use cases where we need to access the store API without using React hooks. For example, in the Plate editor:

```ts
const { usePlateStore } = createPlateStore();
// usePlateStore() returns a memoized object but requires React context
```

With this change, we can now use:
```ts
const { getPlateStore } = createPlateStore();
// getPlateStore() returns the same API without hooks or memoization
```

## Changes
- Added `get<Name>Store` function to the API returned by `createAtomStore`
- The function accepts optional `UseAtomOptionsOrScope` parameter to specify a custom store
- Uses the default Jotai store when no store is provided
- Returns the exact same API as `use<Name>Store()` but without React dependencies
- Added comprehensive tests to ensure functionality

## Test plan
- [x] Added tests for the new `get<Name>Store` function
- [x] All existing tests pass
- [x] TypeScript types are properly defined

🤖 Generated with [Claude Code](https://claude.ai/code)